### PR TITLE
Updating support to Debian Buster. Fixing various other things. 

### DIFF
--- a/playbooks/main/bootstrap_kubernetes.yml
+++ b/playbooks/main/bootstrap_kubernetes.yml
@@ -18,7 +18,7 @@
   
       - name: Copying the kube config to the kube directory.
         become: yes
-        shell: cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+        shell: cp /etc/kubernetes/admin.conf $HOME/.kube/config
   
       - name: Downloading the Calico Pod Network manifest.
         get_url: 
@@ -30,10 +30,6 @@
             path: /tmp/calico.yml
             regexp: 192.168.0.0
             replace: "{{ calico_cidr }}"
-  
-      - name: Adding the role binding for Calico to Kubernetes.
-        become: yes
-        shell: kubectl apply -f {{ calico_rbac_url }}
   
       - name: Applying the Calico Pod Network to Kubernetes.
         become: yes

--- a/playbooks/main/bootstrap_kubernetes.yml
+++ b/playbooks/main/bootstrap_kubernetes.yml
@@ -33,8 +33,7 @@
   
       - name: Applying the Calico Pod Network to Kubernetes.
         become: yes
-        k8s:
-            src: /tmp/calico.yml
+        shell: kubectl apply -f /tmp/calico.yml
   
       - name: Deleting the Calico Pod Network manifest from disk.
         file: 

--- a/playbooks/main/deploy_qcow2_vms.yml
+++ b/playbooks/main/deploy_qcow2_vms.yml
@@ -47,7 +47,7 @@
             - { id: "{{ k8s_node2_id }}", hn: "{{ k8s_node2_hn }}", cpu: "{{ k8s_node2_cpu }}", mem: "{{ k8s_node2_mem }}", bridge: "{{ k8s_node2_bridge }}", gw: "{{ k8s_node2_gw }}", ip: "{{ k8s_node2_ip }}", sn: "{{ k8s_node2_sn }}", ns: "{{ k8s_node2_ns }}", sd: "{{ k8s_node2_sd }}" }
             - { id: "{{ k8s_node3_id }}", hn: "{{ k8s_node3_hn }}", cpu: "{{ k8s_node3_cpu }}", mem: "{{ k8s_node3_mem }}", bridge: "{{ k8s_node3_bridge }}", gw: "{{ k8s_node3_gw }}", ip: "{{ k8s_node3_ip }}", sn: "{{ k8s_node3_sn }}", ns: "{{ k8s_node3_ns }}", sd: "{{ k8s_node3_sd }}" }
 
-      - name: Setting the VLAN Tags and adding a serial device to prevent a Kernel Panic.
+      - name: Setting the VLAN Tags for the VMs. 
         shell: >
             qm set {{ item.id }}
             --net0 "virtio,bridge={{ item.bridge }},tag={{ item.vlan }}"
@@ -70,8 +70,13 @@
         shell: qm importdisk {{ item.id }} {{ qcow2_download_location }}image.qcow2 {{ item.stg }}
         with_items: "{{ id_stg_list }}"
 
-      - name: Configuring the disk as scsi0.
-        shell: qm set {{ item.id }} --scsihw virtio-scsi-pci --scsi0 {{ item.stg }}:vm-{{ item.id }}-disk-0
+      - name: Configuring the VM Hardware. 
+        shell: qm set {{ item.id }} 
+               --scsihw virtio-scsi-pci 
+               --scsi0 {{ item.stg }}:vm-{{ item.id }}-disk-0
+               --ide2 {{ item.stg }}:cloudinit
+               --serial0 /dev/tty0
+               --boot c --bootdisk scsi0
         with_items: "{{ id_stg_list }}"
 
       - name: Resizing the disk. 
@@ -81,18 +86,6 @@
             - { id: "{{ k8s_node1_id }}", size: "{{ k8s_node1_size }}" }
             - { id: "{{ k8s_node2_id }}", size: "{{ k8s_node2_size }}" }
             - { id: "{{ k8s_node3_id }}", size: "{{ k8s_node3_size }}" }
-
-      - name: Adding a cloud-init hardware device.
-        shell: qm set {{ item.id }} --ide2 {{ item.stg }}:cloudinit
-        with_items: "{{ id_stg_list }}"
-
-      - name: Adding a serial device to prevent a Kernel Panic on first boot.
-        shell: qm set {{ item.id }} --serial0 /dev/tty0
-        with_items: "{{ id_stg_list }}"
-
-      - name: Setting the boot disk to scsi0 and restricting BIOS to boot from disk only.
-        shell: qm set {{ item }} --boot c --bootdisk scsi0
-        with_items: "{{ id_list }}"
 
       - name: Starting the VMs.
         shell: qm start {{ item }}

--- a/playbooks/main/deploy_qcow2_vms.yml
+++ b/playbooks/main/deploy_qcow2_vms.yml
@@ -106,6 +106,6 @@
             - "{{ k8s_node2_hn }}"
             - "{{ k8s_node3_hn }}"
 
-      - name: Waiting 120 seconds for for Debian to finish booting.
+      - name: Waiting 30 seconds for for Debian to finish booting.
         pause:
-            seconds: 120
+            seconds: 30

--- a/playbooks/main/deploy_qcow2_vms.yml
+++ b/playbooks/main/deploy_qcow2_vms.yml
@@ -36,26 +36,26 @@
             --agent 1
             --cores {{ item.cpu }}
             --memory {{ item.mem }} 
-            --net0 "virtio,bridge=vmbr0"
+            --net0 "virtio,bridge={{ item.bridge }}"
             --ipconfig0 "gw={{ item.gw }},ip={{ item.ip }}{{ item.sn }}"
             --nameserver {{ item.ns }}
             --searchdomain {{ item.sd }}
             --sshkeys {{ k8s_ssh_key }}
         with_items: 
-            - { id: "{{ k8s_master_id }}", hn: "{{ k8s_master_hn }}", cpu: "{{ k8s_master_cpu }}", mem: "{{ k8s_master_mem }}", gw: "{{ k8s_master_gw }}", ip: "{{ k8s_master_ip }}", sn: "{{ k8s_master_sn }}", ns: "{{ k8s_master_ns }}", sd: "{{ k8s_master_sd }}" }
-            - { id: "{{ k8s_node1_id }}", hn: "{{ k8s_node1_hn }}", cpu: "{{ k8s_node1_cpu }}", mem: "{{ k8s_node1_mem }}", gw: "{{ k8s_node1_gw }}", ip: "{{ k8s_node1_ip }}", sn: "{{ k8s_node1_sn }}", ns: "{{ k8s_node1_ns }}", sd: "{{ k8s_node1_sd }}" }
-            - { id: "{{ k8s_node2_id }}", hn: "{{ k8s_node2_hn }}", cpu: "{{ k8s_node2_cpu }}", mem: "{{ k8s_node2_mem }}", gw: "{{ k8s_node2_gw }}", ip: "{{ k8s_node2_ip }}", sn: "{{ k8s_node2_sn }}", ns: "{{ k8s_node2_ns }}", sd: "{{ k8s_node2_sd }}" }
-            - { id: "{{ k8s_node3_id }}", hn: "{{ k8s_node3_hn }}", cpu: "{{ k8s_node3_cpu }}", mem: "{{ k8s_node3_mem }}", gw: "{{ k8s_node3_gw }}", ip: "{{ k8s_node3_ip }}", sn: "{{ k8s_node3_sn }}", ns: "{{ k8s_node3_ns }}", sd: "{{ k8s_node3_sd }}" }
+            - { id: "{{ k8s_master_id }}", hn: "{{ k8s_master_hn }}", cpu: "{{ k8s_master_cpu }}", mem: "{{ k8s_master_mem }}", bridge: "{{ k8s_master_bridge }}", gw: "{{ k8s_master_gw }}", ip: "{{ k8s_master_ip }}", sn: "{{ k8s_master_sn }}", ns: "{{ k8s_master_ns }}", sd: "{{ k8s_master_sd }}" }
+            - { id: "{{ k8s_node1_id }}", hn: "{{ k8s_node1_hn }}", cpu: "{{ k8s_node1_cpu }}", mem: "{{ k8s_node1_mem }}", bridge: "{{ k8s_node1_bridge }}", gw: "{{ k8s_node1_gw }}", ip: "{{ k8s_node1_ip }}", sn: "{{ k8s_node1_sn }}", ns: "{{ k8s_node1_ns }}", sd: "{{ k8s_node1_sd }}" }
+            - { id: "{{ k8s_node2_id }}", hn: "{{ k8s_node2_hn }}", cpu: "{{ k8s_node2_cpu }}", mem: "{{ k8s_node2_mem }}", bridge: "{{ k8s_node2_bridge }}", gw: "{{ k8s_node2_gw }}", ip: "{{ k8s_node2_ip }}", sn: "{{ k8s_node2_sn }}", ns: "{{ k8s_node2_ns }}", sd: "{{ k8s_node2_sd }}" }
+            - { id: "{{ k8s_node3_id }}", hn: "{{ k8s_node3_hn }}", cpu: "{{ k8s_node3_cpu }}", mem: "{{ k8s_node3_mem }}", bridge: "{{ k8s_node3_bridge }}", gw: "{{ k8s_node3_gw }}", ip: "{{ k8s_node3_ip }}", sn: "{{ k8s_node3_sn }}", ns: "{{ k8s_node3_ns }}", sd: "{{ k8s_node3_sd }}" }
 
       - name: Setting the VLAN Tags.
         shell: >
             qm set {{ item.id }}
-            --net0 "virtio,bridge=vmbr0,tag={{ item.vlan }}"
+            --net0 "virtio,bridge={{ item.bridge }},tag={{ item.vlan }}"
         with_items:
-            - { id: "{{ k8s_master_id }}", vlan: "{{ k8s_master_vlan }}" }
-            - { id: "{{ k8s_node1_id }}", vlan: "{{ k8s_node1_vlan }}" }
-            - { id: "{{ k8s_node2_id }}", vlan: "{{ k8s_node2_vlan }}" }
-            - { id: "{{ k8s_node3_id }}", vlan: "{{ k8s_node3_vlan }}" }
+            - { id: "{{ k8s_master_id }}", bridge: "{{ k8s_master_bridge }}", vlan: "{{ k8s_master_vlan }}" }
+            - { id: "{{ k8s_node1_id }}", bridge: "{{ k8s_node1_bridge }}", vlan: "{{ k8s_node1_vlan }}" }
+            - { id: "{{ k8s_node2_id }}", bridge: "{{ k8s_node2_bridge }}", vlan: "{{ k8s_node2_vlan }}" }
+            - { id: "{{ k8s_node3_id }}", bridge: "{{ k8s_node3_bridge }}", vlan: "{{ k8s_node3_vlan }}" }
         when: 
             - k8s_master_vlan is defined 
             - k8s_master_vlan|length != 0
@@ -66,7 +66,7 @@
             - k8s_node3_vlan is defined
             - k8s_node3_vlan|length != 0
 
-      - name: Setting Serial device
+      - name: Adding a serial device to avoid a Kernel Panic on first boot.
         shell: qm set {{ item.id }} --serial0 /dev/tty0
         with_items: "{{ id_stg_list }}"
 
@@ -92,18 +92,6 @@
 
       - name: Setting the boot disk to scsi0 and restricting BIOS to boot from disk only.
         shell: qm set {{ item }} --boot c --bootdisk scsi0
-        with_items: "{{ id_list }}"
-
-      - name: Starting the VMs.
-        shell: qm start {{ item }}
-        with_items: "{{ id_list }}"
-
-      - name: Pausing for 30 seconds to allow the VMs to kernel panic. -_-
-        pause:
-            seconds: 30
-
-      - name: Stopping the VMs.
-        shell: qm stop {{ item }}
         with_items: "{{ id_list }}"
 
       - name: Starting the VMs.

--- a/playbooks/main/deploy_qcow2_vms.yml
+++ b/playbooks/main/deploy_qcow2_vms.yml
@@ -47,10 +47,11 @@
             - { id: "{{ k8s_node2_id }}", hn: "{{ k8s_node2_hn }}", cpu: "{{ k8s_node2_cpu }}", mem: "{{ k8s_node2_mem }}", bridge: "{{ k8s_node2_bridge }}", gw: "{{ k8s_node2_gw }}", ip: "{{ k8s_node2_ip }}", sn: "{{ k8s_node2_sn }}", ns: "{{ k8s_node2_ns }}", sd: "{{ k8s_node2_sd }}" }
             - { id: "{{ k8s_node3_id }}", hn: "{{ k8s_node3_hn }}", cpu: "{{ k8s_node3_cpu }}", mem: "{{ k8s_node3_mem }}", bridge: "{{ k8s_node3_bridge }}", gw: "{{ k8s_node3_gw }}", ip: "{{ k8s_node3_ip }}", sn: "{{ k8s_node3_sn }}", ns: "{{ k8s_node3_ns }}", sd: "{{ k8s_node3_sd }}" }
 
-      - name: Setting the VLAN Tags.
+      - name: Setting the VLAN Tags and adding a serial device to prevent a Kernel Panic.
         shell: >
             qm set {{ item.id }}
             --net0 "virtio,bridge={{ item.bridge }},tag={{ item.vlan }}"
+            --serial0 /dev/tty0
         with_items:
             - { id: "{{ k8s_master_id }}", bridge: "{{ k8s_master_bridge }}", vlan: "{{ k8s_master_vlan }}" }
             - { id: "{{ k8s_node1_id }}", bridge: "{{ k8s_node1_bridge }}", vlan: "{{ k8s_node1_vlan }}" }
@@ -65,10 +66,6 @@
             - k8s_node2_vlan|length != 0
             - k8s_node3_vlan is defined
             - k8s_node3_vlan|length != 0
-
-      - name: Adding a serial device to avoid a Kernel Panic on first boot.
-        shell: qm set {{ item.id }} --serial0 /dev/tty0
-        with_items: "{{ id_stg_list }}"
 
       - name: Importing the qcow2 image as a disk.
         shell: qm importdisk {{ item.id }} {{ qcow2_download_location }}image.qcow2 {{ item.stg }}

--- a/playbooks/main/deploy_qcow2_vms.yml
+++ b/playbooks/main/deploy_qcow2_vms.yml
@@ -51,7 +51,6 @@
         shell: >
             qm set {{ item.id }}
             --net0 "virtio,bridge={{ item.bridge }},tag={{ item.vlan }}"
-            --serial0 /dev/tty0
         with_items:
             - { id: "{{ k8s_master_id }}", bridge: "{{ k8s_master_bridge }}", vlan: "{{ k8s_master_vlan }}" }
             - { id: "{{ k8s_node1_id }}", bridge: "{{ k8s_node1_bridge }}", vlan: "{{ k8s_node1_vlan }}" }
@@ -83,8 +82,12 @@
             - { id: "{{ k8s_node2_id }}", size: "{{ k8s_node2_size }}" }
             - { id: "{{ k8s_node3_id }}", size: "{{ k8s_node3_size }}" }
 
-      - name: Adding a Cloud-init hardware device.
+      - name: Adding a cloud-init hardware device.
         shell: qm set {{ item.id }} --ide2 {{ item.stg }}:cloudinit
+        with_items: "{{ id_stg_list }}"
+
+      - name: Adding a serial device to prevent a Kernel Panic on first boot.
+        shell: qm set {{ item.id }} --serial0 /dev/tty0
         with_items: "{{ id_stg_list }}"
 
       - name: Setting the boot disk to scsi0 and restricting BIOS to boot from disk only.

--- a/playbooks/main/install_base_packages.yml
+++ b/playbooks/main/install_base_packages.yml
@@ -18,7 +18,7 @@
       - name: Installing the base packages.
         become: yes
         apt:
-            name: ['apt-transport-https', 'ca-certificates', 'curl', 'gnupg2', 'openssl', 'python-pip', 'qemu-guest-agent', 'software-properties-common']
+            name: ['apt-transport-https', 'ca-certificates', 'curl', 'haveged', 'gnupg2', 'openssl', 'python-pip', 'qemu-guest-agent', 'software-properties-common']
             
       - name: Adding the necessary GPG keys.
         become: yes
@@ -33,7 +33,7 @@
         apt_repository:
             repo: "{{ item }}"
         with_items:
-            - "deb [arch=amd64] https://download.docker.com/linux/debian stretch stable"
+            - "deb [arch=amd64] https://download.docker.com/linux/debian buster stable"
             - "deb https://apt.kubernetes.io/ kubernetes-xenial main"
 
       - name: Updating the package repositories.
@@ -62,3 +62,4 @@
             - "docker"
             - "kubelet"
             - "qemu-guest-agent"
+            - "haveged"

--- a/playbooks/optional/delete_all_resources.yml
+++ b/playbooks/optional/delete_all_resources.yml
@@ -24,6 +24,7 @@
 
       - name: Deleting the Resource Pool.
         shell: pvesh delete /pools/{{ k8s_resource_pool }}
+        ignore_errors: yes
 
       - name: Deleting the Debian qcow2 image.
         file:

--- a/vars.yml
+++ b/vars.yml
@@ -6,9 +6,9 @@
 
 # qcow2 image to use for your Virtual Machines: 
 # Can be found here: https://cdimage.debian.org/cdimage/openstack/current/?C=M;O=A 
-qcow2_image: 'https://cdimage.debian.org/cdimage/openstack/current/debian-9.8.2-20190303-openstack-amd64.qcow2'
+qcow2_image: 'https://cdimage.debian.org/cdimage/openstack/current/debian-10.0.1-20190708-openstack-amd64.qcow2'
 
-# Location to use for storing the qcow2 image. Be sure to end the directory with a '/'.
+# Location to use for storing the qcow2 image. Be sure to end the absolute path with a '/'.
 qcow2_download_location: '/tmp/'
 
 # Resource Pool for your virtual machines.
@@ -36,10 +36,10 @@ k8s_node2_cpu: "4"
 k8s_node3_cpu: "4"
 
 # Amount of memory expressed in megabytes
-k8s_master_mem: "4096"
-k8s_node1_mem: "8192"
-k8s_node2_mem: "8192"
-k8s_node3_mem: "8192"
+k8s_master_mem: "5120"
+k8s_node1_mem: "10240"
+k8s_node2_mem: "10240"
+k8s_node3_mem: "10240"
 
 # Disk Sizes
 k8s_master_size: "50G"
@@ -92,13 +92,9 @@ k8s_node3_stg: "SaturnPool"
 # CIDR for the Calico Pod Network - MUST be different from your Kubernetes CIDR to avoid an IP conflict. Subnet size will automatically be set to /16.
 calico_cidr: '172.16.0.0'
 
-# URL for the RBAC Policy for the Calico Network Policy: 
-# Can be found here: https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#tabs-pod-install-1
-calico_rbac_url: "https://docs.projectcalico.org/v3.3/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml"
-
 # URL for the Calico Network Policy: 
-# Can be found here: https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#tabs-pod-install-1
-calico_policy_url: 'https://docs.projectcalico.org/v3.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml'
+# Can be found here: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#tabs-pod-install-2
+calico_policy_url: 'https://docs.projectcalico.org/v3.8/manifests/calico.yaml'
 
 # The URL for the Kubernetes Dashboard Manifest. Not locally hosted as it changes frequently.
 # Can be found in the `Getting Started` section of this page: https://github.com/kubernetes/dashboard/blob/master/README.md

--- a/vars.yml
+++ b/vars.yml
@@ -6,7 +6,7 @@
 
 # qcow2 image to use for your Virtual Machines: 
 # Can be found here: https://cdimage.debian.org/cdimage/openstack/current/?C=M;O=A 
-qcow2_image: 'https://cdimage.debian.org/cdimage/openstack/current/debian-10.0.1-20190708-openstack-amd64.qcow2'
+qcow2_image: 'https://cdimage.debian.org/cdimage/openstack/current/debian-10.0.2-20190721-openstack-amd64.qcow2'
 
 # Location to use for storing the qcow2 image. Be sure to end the absolute path with a '/'.
 qcow2_download_location: '/tmp/'


### PR DESCRIPTION
Updating support to Debian Buster, Calico manifests, and Ansible tas after merging in Kernel Panic fix. Fixing bug where Network Bridge was not actually set based on vars.yml. Removing interactive flag when copying kube config. Adding haveged to generate entropy to improve OS bootstrapping speed. Fixing bug in delete script that caused the playbook to exit if the Resource Group didn't exist. Increasing default VM memory.